### PR TITLE
chore(serde): update to serde v0.8.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,17 @@ license = "MIT/Apache-2.0"
 name = "serializable_enum"
 readme = "README.md"
 repository = "https://github.com/frostly/serializable_enum"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
-serde = "0.7.0"
+serde = "0.8.13"
 
 [dependencies.clippy]
 optional = true
 version = "^0.0"
 
 [dev-dependencies]
-serde_json = "0.7.0"
+serde_json = "0.8.3"
 
 [features]
 nightly-testing = ["clippy"]


### PR DESCRIPTION
No regressions have been found, increasing version numbers should
be sufficent.