### PR TITLE
chore(serde): update deps to allow serde 0.7.* and 0.8.*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,17 @@ license = "MIT/Apache-2.0"
 name = "serializable_enum"
 readme = "README.md"
 repository = "https://github.com/frostly/serializable_enum"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
-serde = "0.7.0"
+serde = ">= 0.7.0, < 0.9.0"
 
 [dependencies.clippy]
 optional = true
 version = "^0.0"
 
 [dev-dependencies]
-serde_json = "0.7.0"
+serde_json = ">= 0.7.0, < 0.9.0"
 
 [features]
 nightly-testing = ["clippy"]


### PR DESCRIPTION
No regressions with serde 0.8.13 have been found, so it should be
safe to allow both 0.7.* and 0.8.*.